### PR TITLE
#3 Provide a path when uploading

### DIFF
--- a/ipyuploads/upload.py
+++ b/ipyuploads/upload.py
@@ -64,6 +64,7 @@ class Upload(DescriptionWidget, ValueWidget, CoreWidget):
     chunk_complete = lambda self, name, count, total: None
     file_complete = lambda self, name: None
     all_files_complete = lambda self, names: None
+    custom_path = lambda self, names: None
 
     def __init__(self, **kwargs):
         super(Upload, self).__init__(**kwargs)
@@ -73,13 +74,15 @@ class Upload(DescriptionWidget, ValueWidget, CoreWidget):
         if 'chunk_complete' in kwargs: self.chunk_complete = kwargs['chunk_complete']
         if 'file_complete' in kwargs: self.file_complete = kwargs['file_complete']
         if 'all_files_complete' in kwargs: self.all_files_complete = kwargs['all_files_complete']
+        if 'custom_path' in kwargs: self.custom_path = kwargs['custom_path']
 
     @default('description')
     def _default_description(self):
         return 'Upload'
 
     @staticmethod
-    def write_chunk(name, encoded_chunk, first_chunk):
+    def write_chunk(name, encoded_chunk, first_chunk, custom_path=''):
+        name = custom_path + name
         mode = 'wb' if first_chunk else 'ab'
         try:
             with open(name, mode) as f:
@@ -94,7 +97,8 @@ class Upload(DescriptionWidget, ValueWidget, CoreWidget):
             name = content.get('file', '')
             encoded_chunk = content.get('chunk', '')
             first_chunk = content.get('count', '') == 1
-            Upload.write_chunk(name, encoded_chunk, first_chunk)
+            Upload.write_chunk(name, encoded_chunk,
+                               first_chunk, self.custom_path)
             self.chunk_complete(name=content.get('file', None),
                                 count=content.get('count', None),
                                 total=content.get('total', None))


### PR DESCRIPTION
Test code used in Jupyter notebook :

```python
import ipyuploads
import ipywidgets

output = ipywidgets.Output()

def chunk_complete(name, count, total):
    """Callback to be executed when a chunk finishes uploading
    
       name - Name of the file being uploaded
       count - A counter of which chunk just finished uploading
       total - The total number of chunks in this file"""
    with output:
        print(f'CHUNK CALLBACK! {name} {count} {total}')

def file_complete(name):
    """Callback to be executed when a file finishes uploading
    
       name - Name of the file that was just uploaded"""
    with output:
        print('FILE CALLBACK! ' + name)

def all_files_complete(metadatas):
    """Callback to be executed once all selected files finish uploading
    
       metadatas - A list of metadata objects, one for each file. Each contains:
                   { 'name': 'the file's name', 
                     'type': 'mime-type of the file', 
                     'last_modified': last modified data as an integer 
                                      (number of milliseconds since the epoch) }"""
    with output:
        print(f'ALL FILES CALLBACK! {metadatas}')

custom_path = "./test_folder"
a = ipyuploads.Upload(accept='txt',           # Accept only text files
                  multiple=True,          # Upload multiple files at once
                  disabled=False,          # Disable the widget
                  icon='cloud-upload',    # Change the upload icon
                  button_stye='primary',  # Change the button style
                  error='Bad Error',      # Set the error message
                  busy=False,             # Whether an upload is in progress
                  chunk_complete=chunk_complete,     # Callback when a chunk upload completes
                  file_complete=file_complete,      # Callback when a file upload completes
                  all_files_complete=all_files_complete, # Callback when all files complete
                  custom_path=custom_path   # Custom path to upload
                  )

a.custom_path
display(a, output)
```